### PR TITLE
[RFR] Replace generators with promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
 #coPostgresQueries
 utility to generate and execute postgresql queries with ease.
 
+##Install
+
+`npm install --save co-postgres-queries`
+
 ##pgClient
 Allow to connect to postgres and execute query
+
+With generators
 ```js
-import { pgCLient } from 'coPostgresQueries';
-const db = new pgClient(dsn);
+import { pgClient } from 'co-postgres-queries';
+
+const db = yield pgClient(dsn);
 yield db.query({ sql, parameters });
+```
+
+With async/await
+```js
+import { pgClient } from 'co-postgres-queries';
+
+const db = await pgClient(dsn);
+await db.query({ sql, parameters });
 ```
 return db object
 ###db.query

--- a/lib/services/pg-client.js
+++ b/lib/services/pg-client.js
@@ -1,10 +1,10 @@
 import pg from 'pg-then';
-import co from 'co';
 import namedToNumericParameter from '../queries/namedToNumericParameter';
-export default function* pgClient(dsn) {
+
+export default (dsn) => {
     const client = new pg.Client(dsn);
 
-    const query = function* query({ sql, parameters }) {
+    const query = ({ sql, parameters }) => {
         if (!sql) {
             throw new Error('sql cannot be null');
         }
@@ -12,63 +12,48 @@ export default function* pgClient(dsn) {
         const parsedSql = result.sql;
         const parsedParameters = result.parameters;
 
-        return (yield client.query(parsedSql, parsedParameters)).rows;
+        return client.query(parsedSql, parsedParameters).then(queryResult => queryResult.rows);
     };
 
-    const begin = function* begin() {
-        yield query({ sql: 'BEGIN' });
-    };
+    const begin = () => query({ sql: 'BEGIN' });
 
-    const rollback = function* rollback(name) {
-        const sql = 'ROLLBACK';
+    const sqlForRollback = 'ROLLBACK';
+    const rollback = name => query({ sql: name ? sqlForRollback.concat(` TO ${name}`) : sqlForRollback });
 
-        yield query({ sql: name ? sql.concat(` TO ${name}`) : sql });
-    };
+    const commit = () => query({ sql: 'COMMIT' });
 
-    const commit = function* commit() {
-        yield query({ sql: 'COMMIT' });
-    };
-
-    const queries = function* queries({ sql, parameters }) {
+    const queries = ({ sql, parameters }) => {
         if (!sql) {
             throw new Error('sql cannot be null');
         }
 
-        yield begin();
-        const result = yield sql.split(';')
-        .reduce((prev, sqlLine) => prev.then(() => co(function* handleResult() {
-            return yield query({ sql: sqlLine, parameters });
-        }))
-        .catch(error => co(function* handleError() {
-            yield rollback();
-            throw error;
-        })), Promise.resolve(null));
-
-        yield commit();
-
-        return result;
+        return begin().then(() => sql
+            .split(';')
+            .reduce((prev, sqlLine) => prev.then(() => query({ sql: sqlLine, parameters }))
+            .catch(error => {
+                rollback().then(() => {
+                    throw error;
+                });
+            }), Promise.resolve(null))
+        ).then(results => commit().then(() => results));
     };
 
-    const queryOne = function* queryOne({ sql, parameters }) {
-        return (yield query({ sql, parameters }))[0];
-    };
+    const queryOne = ({ sql, parameters }) => query({ sql, parameters }).then(result => result[0]);
 
-    const savepoint = function* savePoint(name) {
-        yield query({ sql: `SAVEPOINT ${name}` });
-    };
+    const savepoint = name => query({ sql: `SAVEPOINT ${name}` });
 
-    const id = (yield client.query('SELECT pg_backend_pid()')).rows[0].pg_backend_pid;
-
-    return {
-        ...client,
-        done: client.end.bind(client),
-        query,
-        queries,
-        queryOne,
-        id,
-        begin,
-        commit,
-        savepoint,
-        rollback,
-    };
-}
+    return client.query('SELECT pg_backend_pid()')
+        .then(result => result.rows[0].pg_backend_pid)
+        .then(id => ({
+            ...client,
+            done: client.end.bind(client),
+            query,
+            queries,
+            queryOne,
+            id,
+            begin,
+            commit,
+            savepoint,
+            rollback,
+        }));
+};


### PR DESCRIPTION
- [x] Ensure the library only returns promises instead of generator functions

  This allows clients to use `yield` (when using koa v1 for example)  or `await` (when using koa v2).

- [x] Updated readme to fix some typos and added some usage examples