### PR TITLE
[RFR] Remove totalCount from selectPage query

### DIFF
--- a/lib/queries/selectPage.js
+++ b/lib/queries/selectPage.js
@@ -15,11 +15,8 @@ function selectPage(limit, offset, filters = {}, sort, sortDir) {
     } = this.config;
 
     const where = whereQuery(filters, searchableFields);
-    let sql = (
-`SELECT ${returnFields.join(', ')},
-COUNT(*) OVER() as totalCount
-FROM ${table} ${where}`
-);
+    let sql = `SELECT ${returnFields.join(', ')} FROM ${table} ${where}`;
+
     if (groupByFields.length > 0) {
         sql = `${sql} GROUP BY ${groupByFields.join(', ')}`;
     }

--- a/makefile
+++ b/makefile
@@ -15,6 +15,7 @@ build:
 
 test:
 	@docker-compose up -d db
+	@sleep 3s # Let the DB start
 	@docker-compose run test
 
 install:

--- a/test/functional/crud.js
+++ b/test/functional/crud.js
@@ -92,7 +92,6 @@ describe('crud', () => {
         result.forEach((author, index) => {
             assert.equal(author.name, authors[index].name);
             assert.equal(author.firstname, authors[index].firstname);
-            assert.equal(author.totalcount, 2);
         });
     });
 

--- a/test/queries/selectPage.js
+++ b/test/queries/selectPage.js
@@ -4,11 +4,7 @@ describe('selectPage', () => {
     it('should use a simple query if querying on a single table', function* () {
         const { sql, parameters } = selectPage('table', ['id'], ['field1', 'field2'])();
 
-        assert.equal(sql, (
-`SELECT field1, field2,
-COUNT(*) OVER() as totalCount
-FROM table  ORDER BY id ASC`
-        ));
+        assert.equal(sql, 'SELECT field1, field2 FROM table  ORDER BY id ASC');
         assert.deepEqual(parameters, {});
     });
 
@@ -16,11 +12,7 @@ FROM table  ORDER BY id ASC`
         const { sql, parameters } = selectPage('table', ['id'], ['field1', 'field2'])
         .groupByFields(['field1', 'field2'])();
 
-        assert.equal(sql, (
-`SELECT field1, field2,
-COUNT(*) OVER() as totalCount
-FROM table  GROUP BY field1, field2 ORDER BY id ASC`
-        ));
+        assert.equal(sql, 'SELECT field1, field2 FROM table  GROUP BY field1, field2 ORDER BY id ASC');
         assert.deepEqual(parameters, {});
     });
 
@@ -33,9 +25,7 @@ FROM table  GROUP BY field1, field2 ORDER BY id ASC`
 
         assert.equal(sql, (
 `WITH result AS (
-SELECT field1, field2,
-COUNT(*) OVER() as totalCount
-FROM table1 JOIN table2 ON table1.table2_id table2.id
+SELECT field1, field2 FROM table1 JOIN table2 ON table1.table2_id table2.id
 ) SELECT * FROM result ORDER BY id ASC`
 ));
         assert.deepEqual(parameters, {});
@@ -51,9 +41,7 @@ FROM table1 JOIN table2 ON table1.table2_id table2.id
 
         assert.equal(sql, (
 `WITH result AS (
-SELECT field1, field2,
-COUNT(*) OVER() as totalCount
-FROM table1 JOIN table2 ON table1.table2_id table2.id
+SELECT field1, field2 FROM table1 JOIN table2 ON table1.table2_id table2.id
 ) SELECT * FROM result ORDER BY id ASC`
         ));
         assert.deepEqual(parameters, {});
@@ -66,11 +54,7 @@ FROM table1 JOIN table2 ON table1.table2_id table2.id
             ['field1', 'field2']
         )(null, null, { field1: ['value', 'other value'] });
 
-        assert.equal(sql, (
-`SELECT field1, field2,
-COUNT(*) OVER() as totalCount
-FROM table WHERE field1 IN ($field11, $field12) ORDER BY id ASC`
-        ));
+        assert.equal(sql, 'SELECT field1, field2 FROM table WHERE field1 IN ($field11, $field12) ORDER BY id ASC');
         assert.deepEqual(parameters, {
             field11: 'value',
             field12: 'other value',


### PR DESCRIPTION
Here is an example of a response before and after the change:

```diff
[{
      "id": "85b6a307-b77b-4891-a98a-2d0f862890a3",
      "name": "default",
+     "configurations": []
-     "configurations": [],
-     "totalcount": "1"
}]
```

I really think that the count should not be displayed with the real data.

To have the same behavior without this feature, you can just write:

```js
const fields = [
    'id',
    'name',
    'COUNT(*) OVER() as totalCount',
];

const queries = crudQueries('model', fields, ['id']);
```

What's your thought?