### PR TITLE
[RFR] Add allowPrimaryKeyUpdate configuration on updateOne

### DIFF
--- a/lib/queries/updateOne.js
+++ b/lib/queries/updateOne.js
@@ -9,6 +9,7 @@ function updateOne(id, data) {
         idFields,
         updatableFields,
         returnFields,
+        allowPrimaryKeyUpdate,
     } = this.config;
 
     const identifiers = sanitizeIdentifier(idFields, id);
@@ -20,7 +21,9 @@ function updateOne(id, data) {
     const where = whereQuery(identifiers, idFields);
 
     const setQuery = updatableFields.reduce((result, field) => {
-        if (idFields.indexOf(field) !== -1 || typeof data[field] === 'undefined') {
+        const isPrimaryKey = idFields.indexOf(field) !== -1;
+
+        if ((!allowPrimaryKeyUpdate && isPrimaryKey)|| typeof data[field] === 'undefined') {
             return result;
         }
 
@@ -53,8 +56,8 @@ export default function (table, updatableFields, idFields = ['id'], returnFields
         updatableFields,
         idFields: [].concat(idFields),
         returnFields,
+        allowPrimaryKeyUpdate: false,
     };
-
 
     return configurable(updateOne, config);
 }


### PR DESCRIPTION
Add a configuration to allow primary key update for `updateOne`.

Should be called like:
```js
const query = crudQueries(table, fields, idFields, returnFields);
query.updateOne.allowPrimaryKeyUpdate(true);
```