### PR TITLE
[RFR] Accept IS NOT NULL and IS NULL as value

### DIFF
--- a/lib/queries/helpers/whereQuery.js
+++ b/lib/queries/helpers/whereQuery.js
@@ -4,7 +4,9 @@ export function getColPlaceHolder(column, value) {
     const type = Array.isArray(value) ? 'IN' : value;
     switch (type) {
     case 'IS_NULL':
+    case 'IS NULL':
     case 'IS_NOT_NULL':
+    case 'IS NOT NULL':
         return value;
     case 'IN':
         return `IN (${value.map((_, index) => `$${column.replace('.', '__')}${index + 1}`).join(', ')})`;

--- a/lib/queries/helpers/whereQuery.spec.js
+++ b/lib/queries/helpers/whereQuery.spec.js
@@ -31,9 +31,14 @@ describe('whereQuery', () => {
     describe('getColPlaceHolder', () => {
         it('should return value if value is IS_NULL or IS_NOT_NULL', () => {
             assert.equal(whereQueryGet.getColPlaceHolder('colName', 'IS_NULL'), 'IS_NULL');
+            assert.equal(whereQueryGet.getColPlaceHolder('colName', 'IS NULL'), 'IS NULL');
             assert.equal(
                 whereQueryGet.getColPlaceHolder('colName', 'IS_NOT_NULL'),
                 'IS_NOT_NULL'
+            );
+            assert.equal(
+                whereQueryGet.getColPlaceHolder('colName', 'IS NOT NULL'),
+                'IS NOT NULL'
             );
         });
 


### PR DESCRIPTION
For exemple if you search for a date column that is null, you have to query with
``` 
WHERE date_column IS NULL
```
`IS_NULL` doesn't work.