### PR TITLE
[RFR] pg as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
     "eslint-plugin-mocha": "4.9.0",
     "eslint-plugin-react": "7.0.1",
     "mocha": "3.4.2",
-    "moment": "2.18.1"
+    "moment": "2.18.1",
+    "pg": "6.2.3"
   },
-  "dependencies": {
+  "peerDependencies": {
     "pg": "6.2.3"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "eslint-plugin-react": "7.0.1",
     "mocha": "3.4.2",
     "moment": "2.18.1",
-    "pg": "6.2.3"
+    "pg": "^6.2.3"
   },
   "peerDependencies": {
-    "pg": "6.2.3"
+    "pg": "^6.2.3"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mocha": "3.4.2",
     "moment": "2.18.1"
   },
-  "peerDependencies": {
+  "dependencies": {
     "pg": "6.2.3"
   },
   "repository": {


### PR DESCRIPTION
When `pg` was set as `peerDependencies`, `make test` threw the error : 
```
Error: Cannot find module 'pg'
```