### PR TITLE
[RFR] Permanent filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,7 @@ crud({
     writableCols,
     primaryKey,
     returnCols,
+    permanentFilters,
 });
 ```
 
@@ -782,6 +783,7 @@ Creates configured queries for insertOne, batchInsert, selectOne, select, update
     specify that we want to encompass the query in `WITH RESULT AS <query> SELECT * FROM result`
     This add a temporary result table that allow to sort on computed and joined column.
     if the table configuration contain a JOIN clause, this will be automatically set to true.
+- permanentFilters: List of filters applied by default, e. g. for a soft delete with permanentFilters as `{ deleted_at: null}`
 
 #### transaction helper
 

--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ upsertOne({
     primaryKey,
     writableCols,
     returnCols,
+    permanentFilters,
 })(row)
 ```
 
@@ -700,6 +701,7 @@ Creates a query to update one row or create it if it does not already exists.
 - primaryKey: One or more columns representing the primary key. Accept either an array or a single value. (default: `id`)
 - writableCols: the column that can be updated
 - returnCols: the column to return in the result
+- permanentFilters: List of filters applied by default, e. g. for a soft delete with permanentFilters as `{ deleted_at: null}`
 
 ##### Parameters
 

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ An array of literal objects in the form of:
 
 ```js
 import selectOne  from 'co-postgres-queries/queries/selectOne';
-selectOne({ table, primaryKey, returnCols })(row)
+selectOne({ table, primaryKey, returnCols, permanentFilters })(row)
 ```
 
 Creates a query to select one row.
@@ -428,6 +428,7 @@ Creates a query to select one row.
 - table: the table name
 - primaryKey: One or more columns representing the primary key. Accept either an array or a single value. (default: `id`)
 - returnCols: list of columns retrieved by the query
+- permanentFilters: List of filters applied by default, e. g. for a soft delete with permanentFilters as `{ deleted_at: null}`
 
 ##### Parameters
 

--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ batchUpsert({
     primaryKey,
     writableCols,
     returnCols,
+    permanentFilters,
 })(rows)
 ```
 
@@ -728,6 +729,7 @@ Creates a query to update a batch row creating those that does not already exist
 - writableCols: the column that can be updated
 - returnCols: the column to return in the result
 - columns: all the columns accepted by the query, default to selectorcolumns + writableCols (no reason to change that)
+- permanentFilters: List of filters applied by default, e. g. for a soft delete with permanentFilters as `{ deleted_at: null}`
 
 ##### Parameters
 

--- a/README.md
+++ b/README.md
@@ -528,6 +528,20 @@ A literal object with:
 - sortDir:
     Specify the sort direction, either 'ASC' or 'DESC'
 
+#### countAll
+
+```js
+import countAll  from 'co-postgres-queries/queries/countAll';
+countAll({ table, permanentFilters })()
+```
+
+Creates a query to count all rows.
+
+##### Configuration
+
+- table: the table name
+- permanentFilters: List of filters applied by default, e. g. for a soft delete with permanentFilters as `{ deleted_at: null}`
+
 
 #### update
 

--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ Two arguments:
 
 ```js
 import remove  from 'co-postgres-queries/queries/remove';
-remove({ table, filterCols, returnCols })(filters);
+remove({ table, filterCols, returnCols, permanentFilters })(filters);
 ```
 
 Creates a query to delete rows.
@@ -621,6 +621,7 @@ Creates a query to delete rows.
 - table: the table name
 - filterCols: the columns that can be used to filter the updated rows
 - returnCols: list of columns retrieved by the query
+- permanentFilters: List of filters applied by default, e. g. for a soft delete with permanentFilters as `{ deleted_at: null}`
 
 ##### Parameters
 
@@ -639,7 +640,7 @@ will update only row for which column equal 'value'
 
 ```js
 import removeOne  from 'co-postgres-queries/queries/removeOne';
-removeOne({ table, primaryKey, returnCols })(identitfier);
+removeOne({ table, primaryKey, returnCols, permanentFilters })(identitfier);
 ```
 
 Creates a query to delete one row.
@@ -649,6 +650,7 @@ Creates a query to delete one row.
 - table: the table name
 - primaryKey: One or more columns representing the primary key. Accept either an array or a single value. (default: `id`)
 - returnCols: list of columns retrieved by the query
+- permanentFilters: List of filters applied by default, e. g. for a soft delete with permanentFilters as `{ deleted_at: null}`
 
 ##### Parameters
 

--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ update({
     writableCols,
     filterCols,
     returnCols,
+    permanentFilters,
 })(filters, data);
 ```
 
@@ -563,6 +564,7 @@ Creates a query to update rows.
 - writableCols: the columns that can be updated
 - filterCols: the columns that can be used to filter the updated rows
 - returnCols: the columns to be returned in the result
+- permanentFilters: List of filters applied by default, e. g. for a soft delete with permanentFilters as `{ deleted_at: null}`
 
 ##### Parameters
 
@@ -588,6 +590,7 @@ updateOne({
     writableCols,
     primaryKey,
     returnCols,
+    permanentFilters,
 })(identifier, data);
 ```
 
@@ -599,6 +602,7 @@ Creates a query to update one row.
 - writableCols: the columns that can be updated
 - primaryKey: One or more columns representing the primary key. Accept either an array or a single value. (default: `id`)
 - returnCols: the columns to be returned in the result
+- permanentFilters: List of filters applied by default, e. g. for a soft delete with permanentFilters as `{ deleted_at: null}`
 
 ##### Parameters
 

--- a/README.md
+++ b/README.md
@@ -456,6 +456,7 @@ select({
     specificSorts,
     groupByCols,
     withQuery,
+    permanentFilters,
     returnOne,
 })({ limit, offset, filters, sort, sortDir });
 ```
@@ -486,6 +487,7 @@ Creates a query to select one row.
     specify that we want to encompass the query in `WITH RESULT AS <query> SELECT * FROM result`
     This add a temporary result table that allow to sort on computed and joined column.
     if the table configuration contain a JOIN clause, this will be automatically set to true.
+- permanentFilters: List of filters applied by default, e. g. for a soft delete with permanentFilters as `{ deleted_at: null}`
 - returnOne: Optional, if set to true, returns only the first result instead of an array.
 
 ##### Parameters

--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ The identifier: either a single value for a single primaryKey column, or a liter
 
 ```js
 import batchRemove  from 'co-postgres-queries/queries/batchRemove';
-batchRemove({ table, primaryKey, returnCols })(identifierList);
+batchRemove({ table, primaryKey, returnCols, permanentFilters })(identifierList);
 ```
 
 Allow to create a query to delete several row at once
@@ -670,6 +670,7 @@ Allow to create a query to delete several row at once
 - table: the table name
 - columns: list of columns to insert
 - primaryKey: One or more columns representing the primary key. Accept either an array or a single value. (default: `id`)
+- permanentFilters: List of filters applied by default, e. g. for a soft delete with permanentFilters as `{ deleted_at: null}`
 
 ##### Parameters
 

--- a/lib/queries/batchRemove.js
+++ b/lib/queries/batchRemove.js
@@ -4,7 +4,7 @@ import combineLiterals from '../utils/combineLiterals';
 import whereQuery from './helpers/whereQuery';
 import returningQuery from './helpers/returningQuery';
 
-export default ({ table, returnCols, primaryKey = ['id'] }) => {
+export default ({ table, returnCols, primaryKey = ['id'], permanentFilters = {} }) => {
     const returning = returningQuery(returnCols);
     const selector = [].concat(primaryKey);
 
@@ -16,11 +16,22 @@ export default ({ table, returnCols, primaryKey = ['id'] }) => {
 
         const where = whereQuery(combineLiterals(cleanIds), selector);
 
-        const sql = `DELETE FROM ${table} ${where} ${returning};`;
+        const permanentFiltersKeys = Object.keys(permanentFilters);
+        let permanentWhere = '';
+        let permanentParameters = {};
+        if (permanentFiltersKeys.length) {
+            permanentParameters = sanitizeIdentifier(permanentFiltersKeys, permanentFilters);
+            permanentWhere = whereQuery(permanentParameters, permanentFiltersKeys).replace('WHERE', ' AND');
+        }
+
+        const sql = `DELETE FROM ${table} ${where}${permanentWhere} ${returning};`;
 
         return {
             sql,
-            parameters,
+            parameters: {
+                ...parameters,
+                ...permanentParameters,
+            },
         };
     };
 };

--- a/lib/queries/batchRemove.js
+++ b/lib/queries/batchRemove.js
@@ -14,23 +14,21 @@ export default ({ table, returnCols, primaryKey = ['id'], permanentFilters = {} 
 
         const parameters = batchParameter(selector)(cleanIds);
 
-        const where = whereQuery(combineLiterals(cleanIds), selector);
+        const where = whereQuery({
+            ...combineLiterals(cleanIds),
+            ...permanentFilters,
+        }, [
+            ...selector,
+            ...Object.keys(permanentFilters),
+        ]);
 
-        const permanentFiltersKeys = Object.keys(permanentFilters);
-        let permanentWhere = '';
-        let permanentParameters = {};
-        if (permanentFiltersKeys.length) {
-            permanentParameters = sanitizeIdentifier(permanentFiltersKeys, permanentFilters);
-            permanentWhere = whereQuery(permanentParameters, permanentFiltersKeys).replace('WHERE', ' AND');
-        }
-
-        const sql = `DELETE FROM ${table} ${where}${permanentWhere} ${returning};`;
+        const sql = `DELETE FROM ${table} ${where} ${returning};`;
 
         return {
             sql,
             parameters: {
                 ...parameters,
-                ...permanentParameters,
+                ...permanentFilters,
             },
         };
     };

--- a/lib/queries/batchRemove.spec.js
+++ b/lib/queries/batchRemove.spec.js
@@ -34,4 +34,23 @@ describe('QUERY batchRemove', () => {
             },
         });
     });
+
+    it('should apply permanent filters', () => {
+        const batchRemoveQuery = batchRemoveQuerier({
+            table: 'table',
+            returnCols: ['columna', 'columnb'],
+            primaryKey: ['id1', 'id2'],
+            permanentFilters: { columnc: 'foo' },
+        });
+        assert.deepEqual(batchRemoveQuery([{ id1: 1, id2: 2 }, { id1: 3, id2: 4 }]), {
+            sql: 'DELETE FROM table WHERE id1 IN ($id11, $id12) AND id2 IN ($id21, $id22) AND columnc = $columnc RETURNING columna, columnb;',
+            parameters: {
+                id11: 1,
+                id21: 2,
+                id12: 3,
+                id22: 4,
+                columnc: 'foo',
+            },
+        });
+    });
 });

--- a/lib/queries/batchUpsert.js
+++ b/lib/queries/batchUpsert.js
@@ -1,6 +1,5 @@
 import valueSubQuery from './helpers/valueSubQuery';
 import batchParameter from './helpers/batchParameter';
-import sanitizeIdentifier from './helpers/sanitizeIdentifier';
 import whereQuery from './helpers/whereQuery';
 
 export default ({
@@ -25,12 +24,9 @@ export default ({
     const parameters = getParameter(rows);
 
     const permanentFiltersKeys = Object.keys(permanentFilters);
-    let where = '';
-    let permanentParameters = {};
-    if (permanentFiltersKeys.length) {
-        permanentParameters = sanitizeIdentifier(permanentFiltersKeys, permanentFilters);
-        where = whereQuery(permanentParameters, permanentFiltersKeys);
-    }
+    const where = permanentFiltersKeys.length
+        ? whereQuery(permanentFilters, permanentFiltersKeys)
+        : '';
 
     const sql = (
 `INSERT INTO ${table}
@@ -41,5 +37,11 @@ DO UPDATE SET ${setQuery.join(', ')} ${where}
 RETURNING ${returning}`
     );
 
-    return { sql, parameters };
+    return {
+        sql,
+        parameters: {
+            ...parameters,
+            ...permanentFilters,
+        },
+    };
 };

--- a/lib/queries/batchUpsert.js
+++ b/lib/queries/batchUpsert.js
@@ -1,19 +1,22 @@
 import valueSubQuery from './helpers/valueSubQuery';
 import batchParameter from './helpers/batchParameter';
+import sanitizeIdentifier from './helpers/sanitizeIdentifier';
+import whereQuery from './helpers/whereQuery';
 
 export default ({
     table,
     primaryKey,
     writableCols,
     returnCols = ['*'],
+    permanentFilters = {},
 }) => (rows) => {
-    const columns = primaryKey.concat(writableCols.filter((f) => primaryKey.indexOf(f) === -1));
+    const columns = primaryKey.concat(writableCols.filter(f => primaryKey.indexOf(f) === -1));
     const getValueSubQuery = valueSubQuery(columns);
     const getParameter = batchParameter(columns);
 
     const returning = returnCols.join(', ');
 
-    const setQuery = writableCols.map((col) => `${col} = excluded.${col}`);
+    const setQuery = writableCols.map(col => `${col} = excluded.${col}`);
 
     const values = rows
         .map((_, index) => getValueSubQuery(index + 1))
@@ -21,12 +24,20 @@ export default ({
 
     const parameters = getParameter(rows);
 
+    const permanentFiltersKeys = Object.keys(permanentFilters);
+    let where = '';
+    let permanentParameters = {};
+    if (permanentFiltersKeys.length) {
+        permanentParameters = sanitizeIdentifier(permanentFiltersKeys, permanentFilters);
+        where = whereQuery(permanentParameters, permanentFiltersKeys);
+    }
+
     const sql = (
 `INSERT INTO ${table}
 (${columns.join(', ')})
 VALUES ${values.join(', ')}
 ON CONFLICT (${primaryKey.join(', ')})
-DO UPDATE SET ${setQuery.join(', ')}
+DO UPDATE SET ${setQuery.join(', ')} ${where}
 RETURNING ${returning}`
     );
 

--- a/lib/queries/countAll.js
+++ b/lib/queries/countAll.js
@@ -1,5 +1,17 @@
-export default ({ table }) => () => {
-    const sql = `SELECT COUNT(*) FROM ${table};`;
+import sanitizeIdentifier from './helpers/sanitizeIdentifier';
+import whereQuery from './helpers/whereQuery';
 
-    return { sql, returnOne: true };
+export default ({ table, permanentFilters = false }) => () => {
+    if (!permanentFilters) {
+        const sql = `SELECT COUNT(*) FROM ${table};`;
+
+        return { sql, returnOne: true };
+    }
+
+    const identifiers = Object.keys(permanentFilters);
+    const parameters = sanitizeIdentifier(identifiers, permanentFilters);
+    const where = whereQuery(parameters, identifiers);
+    const sql = `SELECT COUNT(*) FROM ${table} ${where};`;
+
+    return { sql, parameters, returnOne: true };
 };

--- a/lib/queries/countAll.js
+++ b/lib/queries/countAll.js
@@ -1,4 +1,3 @@
-import sanitizeIdentifier from './helpers/sanitizeIdentifier';
 import whereQuery from './helpers/whereQuery';
 
 export default ({ table, permanentFilters = {} }) => () => {
@@ -9,9 +8,8 @@ export default ({ table, permanentFilters = {} }) => () => {
         return { sql, returnOne: true };
     }
 
-    const parameters = sanitizeIdentifier(identifiers, permanentFilters);
-    const where = whereQuery(parameters, identifiers);
+    const where = whereQuery(permanentFilters, identifiers);
     const sql = `SELECT COUNT(*) FROM ${table} ${where};`;
 
-    return { sql, parameters, returnOne: true };
+    return { sql, parameters: permanentFilters, returnOne: true };
 };

--- a/lib/queries/countAll.js
+++ b/lib/queries/countAll.js
@@ -1,14 +1,14 @@
 import sanitizeIdentifier from './helpers/sanitizeIdentifier';
 import whereQuery from './helpers/whereQuery';
 
-export default ({ table, permanentFilters = false }) => () => {
-    if (!permanentFilters) {
+export default ({ table, permanentFilters = {} }) => () => {
+    const identifiers = Object.keys(permanentFilters);
+    if (!identifiers.length) {
         const sql = `SELECT COUNT(*) FROM ${table};`;
 
         return { sql, returnOne: true };
     }
 
-    const identifiers = Object.keys(permanentFilters);
     const parameters = sanitizeIdentifier(identifiers, permanentFilters);
     const where = whereQuery(parameters, identifiers);
     const sql = `SELECT COUNT(*) FROM ${table} ${where};`;

--- a/lib/queries/countAll.spec.js
+++ b/lib/queries/countAll.spec.js
@@ -10,4 +10,22 @@ describe('QUERY countAll', () => {
             returnOne: true,
         });
     });
+
+    it('should generate sql to count all row by applying permanent filters', () => {
+        const countAllQuery = countAllQuerier({
+            table: 'table',
+            permanentFilters: {
+                column1: 'foo',
+                column2: 'bar',
+            },
+        });
+        assert.deepEqual(countAllQuery(), {
+            sql: 'SELECT COUNT(*) FROM table WHERE column1 = $column1 AND column2 = $column2;',
+            parameters: {
+                column1: 'foo',
+                column2: 'bar',
+            },
+            returnOne: true,
+        });
+    });
 });

--- a/lib/queries/crud.js
+++ b/lib/queries/crud.js
@@ -19,7 +19,7 @@ export default function ({
     permanentFilters = {},
     allowPrimaryKeyUpdate,
 }) {
-    const removeOne = removeOneQuery({ table, primaryKey });
+    const removeOne = removeOneQuery({ table, primaryKey, permanentFilters });
     const insertOne = insertOneQuery({ table, writableCols, returnCols });
     const selectOne = selectOneQuery({ table, primaryKey, returnCols, permanentFilters });
     const select = selectQuery({
@@ -32,9 +32,16 @@ export default function ({
         withQuery,
         permanentFilters,
     });
-    const updateOne = updateOneQuery({ table, writableCols, primaryKey, returnCols, allowPrimaryKeyUpdate });
+    const updateOne = updateOneQuery({
+        table,
+        writableCols,
+        primaryKey,
+        returnCols,
+        allowPrimaryKeyUpdate,
+        permanentFilters,
+    });
     const batchInsert = batchInsertQuery({ table, writableCols, returnCols });
-    const batchRemove = batchRemoveQuery({ table, returnCols, primaryKey });
+    const batchRemove = batchRemoveQuery({ table, returnCols, primaryKey, permanentFilters });
     const countAll = countAllQuery({ table, permanentFilters });
 
     const queries = {

--- a/lib/queries/crud.js
+++ b/lib/queries/crud.js
@@ -16,16 +16,26 @@ export default function ({
     specificSorts,
     groupByCols,
     withQuery,
+    permanentFilters = {},
     allowPrimaryKeyUpdate,
 }) {
     const removeOne = removeOneQuery({ table, primaryKey });
     const insertOne = insertOneQuery({ table, writableCols, returnCols });
-    const selectOne = selectOneQuery({ table, primaryKey, returnCols });
-    const select = selectQuery({ table, primaryKey, returnCols, searchableCols, specificSorts, groupByCols, withQuery });
+    const selectOne = selectOneQuery({ table, primaryKey, returnCols, permanentFilters });
+    const select = selectQuery({
+        table,
+        primaryKey,
+        returnCols,
+        searchableCols,
+        specificSorts,
+        groupByCols,
+        withQuery,
+        permanentFilters,
+    });
     const updateOne = updateOneQuery({ table, writableCols, primaryKey, returnCols, allowPrimaryKeyUpdate });
     const batchInsert = batchInsertQuery({ table, writableCols, returnCols });
     const batchRemove = batchRemoveQuery({ table, returnCols, primaryKey });
-    const countAll = countAllQuery({ table });
+    const countAll = countAllQuery({ table, permanentFilters });
 
     const queries = {
         removeOne,

--- a/lib/queries/crud.spec.js
+++ b/lib/queries/crud.spec.js
@@ -8,9 +8,10 @@ describe('crud', () => {
     const primaryKey = ['id1', 'id2'];
     const writableCols = ['col1', 'col2'];
     const returnCols = ['*'];
+    const permanentFilters = { col3: 'foo' };
 
     before(() => {
-        crud = crudQueries({ table, writableCols, primaryKey, returnCols });
+        crud = crudQueries({ table, writableCols, primaryKey, returnCols, permanentFilters });
     });
 
     it('should initialize all queries with given parameters', () => {

--- a/lib/queries/remove.js
+++ b/lib/queries/remove.js
@@ -3,12 +3,22 @@ import sanitizeParameter from './helpers/sanitizeParameter';
 import whereQuery from './helpers/whereQuery';
 import returningQuery from './helpers/returningQuery';
 
-export default ({ table, filterCols, returnCols }, _one = false) => {
+export default ({ table, filterCols, returnCols, permanentFilters = {} }, _one = false) => {
     const returning = returningQuery(returnCols);
 
-    return (id) => {
-        const parameters = _one ? sanitizeIdentifier(filterCols, id) : sanitizeParameter(filterCols, id);
-        const where = whereQuery(parameters, filterCols);
+    return (ids) => {
+        const finalFilterCols = [
+            ...filterCols,
+            ...Object.keys(permanentFilters),
+        ];
+        const finalIdentifiers = {
+            ...ids,
+            ...permanentFilters,
+        };
+        const parameters = _one
+            ? sanitizeIdentifier(finalFilterCols, finalIdentifiers)
+            : sanitizeParameter(finalFilterCols, finalIdentifiers);
+        const where = whereQuery(parameters, finalFilterCols);
         const sql = `DELETE FROM ${table} ${where} ${returning}`;
 
         return {

--- a/lib/queries/remove.spec.js
+++ b/lib/queries/remove.spec.js
@@ -1,0 +1,39 @@
+import { assert } from 'chai';
+
+import remove from './remove';
+
+describe('QUERY remove', () => {
+    it('should generate sql and parameter for selecting one row', () => {
+        const removeQuery = remove({
+            table: 'table',
+            filterCols: ['columnA', 'columnB', 'columnC', 'columnD'],
+            returnCols: ['id'],
+        });
+        assert.deepEqual(removeQuery({ columnA: 'foo', columnC: 'bar' }), {
+            sql: 'DELETE FROM table WHERE columnA = $columnA AND columnC = $columnC RETURNING id',
+            parameters: {
+                columnA: 'foo',
+                columnC: 'bar',
+            },
+            returnOne: false,
+        });
+    });
+
+    it('should apply permanent filters', () => {
+        const removeQuery = remove({
+            table: 'table',
+            filterCols: ['columnA', 'columnB', 'columnC'],
+            returnCols: ['id'],
+            permanentFilters: { columnD: 'thisIsIt' },
+        });
+        assert.deepEqual(removeQuery({ columnA: 'foo', columnB: 'bar' }), {
+            sql: 'DELETE FROM table WHERE columnA = $columnA AND columnB = $columnB AND columnD = $columnD RETURNING id',
+            parameters: {
+                columnA: 'foo',
+                columnB: 'bar',
+                columnD: 'thisIsIt',
+            },
+            returnOne: false,
+        });
+    });
+});

--- a/lib/queries/removeOne.js
+++ b/lib/queries/removeOne.js
@@ -4,8 +4,9 @@ export default ({
     table,
     primaryKey = 'id',
     returnCols,
+    permanentFilters = {},
 }) => {
     const filterCols = [].concat(primaryKey);
 
-    return remove({ table, filterCols, returnCols }, true);
+    return remove({ table, filterCols, returnCols, permanentFilters }, true);
 };

--- a/lib/queries/removeOne.spec.js
+++ b/lib/queries/removeOne.spec.js
@@ -8,7 +8,6 @@ describe('QUERY removeOne', () => {
             table: 'table',
             primaryKey: ['id1', 'id2'],
             returnCols: ['columna', 'columnb'],
-            returnOne: true,
         });
         assert.deepEqual(removeOneQuery({ id1: 1, id2: 2 }), {
             sql: 'DELETE FROM table WHERE id1 = $id1 AND id2 = $id2 RETURNING columna, columnb',
@@ -21,12 +20,34 @@ describe('QUERY removeOne', () => {
     });
 
     it('should ignore parameters not in selectors', () => {
-        const removeOneQuery = removeOne({ table: 'table', primaryKey: ['id1', 'id2'], returnCols: ['*'] });
+        const removeOneQuery = removeOne({
+            table: 'table',
+            primaryKey: ['id1', 'id2'],
+            returnCols: ['*'],
+        });
         assert.deepEqual(removeOneQuery({ id1: 1, id2: 2, columna: 'a', columnb: 'b' }), {
             sql: 'DELETE FROM table WHERE id1 = $id1 AND id2 = $id2 RETURNING *',
             parameters: {
                 id1: 1,
                 id2: 2,
+            },
+            returnOne: true,
+        });
+    });
+
+    it('should apply permanent filters', () => {
+        const removeOneQuery = removeOne({
+            table: 'table',
+            primaryKey: ['id1', 'id2'],
+            returnCols: ['columna', 'columnb'],
+            permanentFilters: { columnc: 'foo' },
+        });
+        assert.deepEqual(removeOneQuery({ id1: 1, id2: 2 }), {
+            sql: 'DELETE FROM table WHERE id1 = $id1 AND id2 = $id2 AND columnc = $columnc RETURNING columna, columnb',
+            parameters: {
+                id1: 1,
+                id2: 2,
+                columnc: 'foo',
             },
             returnOne: true,
         });

--- a/lib/queries/select.js
+++ b/lib/queries/select.js
@@ -10,13 +10,24 @@ export default ({
     specificSorts = {},
     groupByCols = [],
     withQuery = table.indexOf('JOIN') !== -1,
+    permanentFilters = {},
     returnOne,
 }) => {
     const primaryKey = [].concat(ids);
     const select = returnCols.length ? returnCols.join(', ') : '*';
 
     return ({ limit, offset, filters = {}, sort, sortDir } = { filters: {} }) => {
-        const where = whereQuery(filters, searchableCols);
+        const finalFilters = {
+            ...filters,
+            ...permanentFilters,
+        };
+        const finalSearchableCols = [
+            ...searchableCols,
+            ...Object.keys(permanentFilters),
+        ];
+
+        const where = whereQuery(finalFilters, finalSearchableCols);
+
         let sql = `SELECT ${select} FROM ${table} ${where}`;
 
         if (groupByCols.length > 0) {
@@ -31,7 +42,7 @@ ${sql.trim()}
             );
         }
 
-        const parameters = flatten(sanitizeParameter(searchableCols, filters));
+        const parameters = flatten(sanitizeParameter(finalSearchableCols, finalFilters));
 
         // always sort by ids to avoid randomness in case of identical sort column value
         const sortQuery = [primaryKey.map(idCol => `${idCol} ASC`).join(', ')];

--- a/lib/queries/select.spec.js
+++ b/lib/queries/select.spec.js
@@ -118,4 +118,16 @@ SELECT column1, column2 FROM table1 JOIN table2 ON table1.table2_id table2.id
         assert.equal(sql, 'SELECT column1, column2 FROM table  ORDER BY CASE $sort WHEN \'master\' THEN 1 WHEN \'expert\' THEN 2 WHEN \'novice\' THEN 3 END  DESC, id ASC');
         assert.deepEqual(parameters, { sort: 'level' });
     });
+
+    it('should apply permanent filters', () => {
+        const { sql, parameters } = select({
+            table: 'table',
+            primaryKey: ['id'],
+            returnCols: ['column1', 'column2'],
+            permanentFilters: { column3: 'foo' },
+        })();
+
+        assert.equal(sql, 'SELECT column1, column2 FROM table WHERE column3 = $column3 ORDER BY id ASC');
+        assert.deepEqual(parameters, { column3: 'foo' });
+    });
 });

--- a/lib/queries/selectOne.js
+++ b/lib/queries/selectOne.js
@@ -1,12 +1,18 @@
 import whereQuery from './helpers/whereQuery';
 import sanitizeIdentifier from './helpers/sanitizeIdentifier';
 
-export default ({ table, primaryKey = 'id', returnCols = ['*'] }) => {
+export default ({ table, primaryKey = 'id', returnCols = ['*'], permanentFilters = {} }) => {
     const select = returnCols.join(', ');
-    const identifiers = [].concat(primaryKey);
+    const identifiers = [
+        ...[].concat(primaryKey),
+        ...Object.keys(permanentFilters),
+    ];
 
     return (rawParameters) => {
-        const parameters = sanitizeIdentifier(identifiers, rawParameters);
+        const parameters = sanitizeIdentifier(identifiers, {
+            ...typeof rawParameters === 'object' ? rawParameters : { [primaryKey]: rawParameters },
+            ...permanentFilters,
+        });
         const where = whereQuery(parameters, identifiers);
 
         const sql = `SELECT ${select} FROM ${table} ${where} LIMIT 1`;

--- a/lib/queries/selectOne.spec.js
+++ b/lib/queries/selectOne.spec.js
@@ -49,4 +49,23 @@ describe('QUERY selectOne', () => {
             returnOne: true,
         });
     });
+
+    it('should generate sql and parameter with permanent filters', () => {
+        const selectOneQuery = selectOneQuerier({
+            table: 'table',
+            primaryKey: ['id1'],
+            returnCols: ['columna', 'columnb'],
+            permanentFilters: { foo: 'bar', bar: 'IS NULL', tor: 'IS NOT NULL' },
+        });
+        assert.deepEqual(selectOneQuery({ id1: 1 }), {
+            sql: 'SELECT columna, columnb FROM table WHERE id1 = $id1 AND foo = $foo AND bar IS NULL AND tor IS NOT NULL LIMIT 1',
+            parameters: {
+                bar: 'IS NULL',
+                foo: 'bar',
+                id1: 1,
+                tor: 'IS NOT NULL',
+            },
+            returnOne: true,
+        });
+    });
 });

--- a/lib/queries/update.js
+++ b/lib/queries/update.js
@@ -9,12 +9,23 @@ export default ({
     writableCols,
     filterCols: selectors,
     returnCols,
+    permanentFilters = {},
 }, _one = false) => {
-    const filterCols = [].concat(selectors);
+    const filterCols = [
+        ...[].concat(selectors),
+        ...Object.keys(permanentFilters),
+    ];
     const returning = returningQuery(returnCols);
 
     return (filter, data) => {
-        const filters = _one ? sanitizeIdentifier(filterCols, filter) : sanitizeParameter(filterCols, filter);
+        // with updateOne query builder the primaryKey is add to the first entry of the filterCols
+        const upgradedFilters = {
+            ...typeof filter === 'object' ? filter : { [selectors[0]]: filter },
+            ...permanentFilters,
+        };
+        const filters = _one
+            ? sanitizeIdentifier(filterCols, upgradedFilters)
+            : sanitizeParameter(filterCols, upgradedFilters);
         const updateParameters = sanitizeParameter(writableCols, data);
         const parameters = {
             ...filters,

--- a/lib/queries/update.spec.js
+++ b/lib/queries/update.spec.js
@@ -72,4 +72,30 @@ RETURNING *`
             returnOne: false,
         });
     });
+
+    it('should apply permanent filters', () => {
+        const updateQuery = updateQuerier({
+            table: 'table',
+            writableCols: ['columna', 'columnb'],
+            filterCols: ['columna', 'columnb'],
+            permanentFilters: { columnc: 'foo' },
+            returnOne: true,
+        });
+        assert.deepEqual(updateQuery({ columna: 1, columnb: 2 }, { columna: 3, columnb: 4 }), {
+            sql: (
+`UPDATE table
+SET columna=$columna_u, columnb=$columnb_u
+WHERE columna = $columna AND columnb = $columnb AND columnc = $columnc
+RETURNING *`
+            ),
+            parameters: {
+                columna_u: 3,
+                columnb_u: 4,
+                columna: 1,
+                columnb: 2,
+                columnc: 'foo',
+            },
+            returnOne: false,
+        });
+    });
 });

--- a/lib/queries/updateOne.js
+++ b/lib/queries/updateOne.js
@@ -5,8 +5,9 @@ export default ({
     writableCols,
     primaryKey = 'id',
     returnCols,
+    permanentFilters = {},
 }) => {
     const filterCols = [].concat(primaryKey);
 
-    return update({ table, writableCols, filterCols, returnCols }, true);
+    return update({ table, writableCols, filterCols, returnCols, permanentFilters }, true);
 };

--- a/lib/queries/updateOne.spec.js
+++ b/lib/queries/updateOne.spec.js
@@ -148,4 +148,30 @@ RETURNING *`
             returnOne: true,
         });
     });
+
+    it('should apply permanent filters', () => {
+        const updateOneQuery = updateOneQuerier({
+            table: 'table',
+            writableCols: ['columna', 'columnb'],
+            primaryKey: ['id', 'uid'],
+            permanentFilters: { columnc: 'foo', columnd: 'bar' },
+        });
+        assert.deepEqual(updateOneQuery({ id: 1, uid: 2 }, { columna: 1, columnb: null }), {
+            sql: (
+`UPDATE table
+SET columna=$columna_u, columnb=$columnb_u
+WHERE id = $id AND uid = $uid AND columnc = $columnc AND columnd = $columnd
+RETURNING *`
+            ),
+            parameters: {
+                id: 1,
+                uid: 2,
+                columna_u: 1,
+                columnb_u: null,
+                columnc: 'foo',
+                columnd: 'bar',
+            },
+            returnOne: true,
+        });
+    });
 });

--- a/lib/queries/upsertOne.js
+++ b/lib/queries/upsertOne.js
@@ -2,12 +2,14 @@ import valueSubQuery from './helpers/valueSubQuery';
 import sanitizeParameter from './helpers/sanitizeParameter';
 import sanitizeIdentifier from './helpers/sanitizeIdentifier';
 import returningQuery from './helpers/returningQuery';
+import whereQuery from './helpers/whereQuery';
 
 export default ({
     table,
     primaryKey: idCols = 'id',
     writableCols,
     returnCols,
+    permanentFilters = {},
 }) => {
     const returning = returningQuery(returnCols);
     const primaryKey = [].concat(idCols);
@@ -23,7 +25,15 @@ export default ({
 
         const setQuery = writableCols
             .filter(column => typeof parameters[column] !== 'undefined')
-            .map((column) => `${column} = $${column}`);
+            .map(column => `${column} = $${column}`);
+
+        const permanentFiltersKeys = Object.keys(permanentFilters);
+        let where = '';
+        let permanentParameters = {};
+        if (permanentFiltersKeys.length) {
+            permanentParameters = sanitizeIdentifier(permanentFiltersKeys, permanentFilters);
+            where = ` ${whereQuery(permanentParameters, permanentFiltersKeys)}`;
+        }
 
         const sql = (
 `INSERT INTO ${table} (${keys.join(', ')})
@@ -31,7 +41,7 @@ VALUES (${values})
 ON CONFLICT (${primaryKey.join(', ')})
 ${
 setQuery.length > 0 ? (
-    `DO UPDATE SET ${setQuery.join(', ')}`
+    `DO UPDATE SET ${setQuery.join(', ')}${where}`
 ) : (
     'DO NOTHING'
 )
@@ -39,6 +49,13 @@ setQuery.length > 0 ? (
 ${returning}`
         );
 
-        return { sql, parameters, returnOne: true };
+        return {
+            sql,
+            parameters: {
+                ...parameters,
+                ...permanentParameters,
+            },
+            returnOne: true,
+        };
     };
 };

--- a/lib/queries/upsertOne.js
+++ b/lib/queries/upsertOne.js
@@ -28,12 +28,9 @@ export default ({
             .map(column => `${column} = $${column}`);
 
         const permanentFiltersKeys = Object.keys(permanentFilters);
-        let where = '';
-        let permanentParameters = {};
-        if (permanentFiltersKeys.length) {
-            permanentParameters = sanitizeIdentifier(permanentFiltersKeys, permanentFilters);
-            where = ` ${whereQuery(permanentParameters, permanentFiltersKeys)}`;
-        }
+        const where = permanentFiltersKeys.length
+            ? ` ${whereQuery(permanentFilters, permanentFiltersKeys)}`
+            : '';
 
         const sql = (
 `INSERT INTO ${table} (${keys.join(', ')})
@@ -53,7 +50,7 @@ ${returning}`
             sql,
             parameters: {
                 ...parameters,
-                ...permanentParameters,
+                ...permanentFilters,
             },
             returnOne: true,
         };

--- a/lib/queries/upsertOne.spec.js
+++ b/lib/queries/upsertOne.spec.js
@@ -114,4 +114,28 @@ RETURNING *`
             returnOne: true,
         });
     });
+
+    it('should apply permanent filters', () => {
+        const upsertOneQuery = upsertOneQuerier({
+            table: 'table',
+            primaryKey: ['id'],
+            writableCols: ['column'],
+            permanentFilters: { columnb: 'foo' },
+        });
+        assert.deepEqual(upsertOneQuery({ column: 'value', id: 1 }), {
+            sql: (
+`INSERT INTO table (id, column)
+VALUES ($id, $column)
+ON CONFLICT (id)
+DO UPDATE SET column = $column WHERE columnb = $columnb
+RETURNING *`
+            ),
+            parameters: {
+                id: 1,
+                column: 'value',
+                columnb: 'foo',
+            },
+            returnOne: true,
+        });
+    });
 });

--- a/makefile
+++ b/makefile
@@ -18,7 +18,13 @@ build:
 test:
 	@docker-compose up -d db
 	@sleep 3s # Let the DB start
+	($(MAKE) test-start && $(MAKE) test-stop) || ($(MAKE) test-stop && exit 1)
+
+test-start:
 	@docker-compose run test
+
+test-stop:
+	@docker-compose down
 
 install:
 	docker-compose run --rm npm install


### PR DESCRIPTION
Add an `permanentFilters` option to the select query builders to apply permanent filters to all queries. For example, if the model has a `deleted_at` column for setting up soft delete, a `{ deleted_at: null }` as permanentFilters will always exclude all records with a not null deleted_at from query returns.

Add `permanentFilters` option to: 
- [x] selectOne
- [x] select
- [x] countAll
- [x] crud

And also
- [x] batchRemove
- [x] batchUpsert
- [x] remove
- [x] removeOne
- [x] update
- [x] updateOne
- [x] upsertOne