### PR TITLE
[RFR] Add documentation about JOIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,7 +476,14 @@ Creates a query to select one row.
 ##### Configuration
 
 - table:
-  the table name, accept JOIN statements
+  the table name, accept JOIN statements    
+  exemple:
+  
+  ```js
+  {
+    table: 'table1 JOIN table2 ON table1.table2_id = table2.id'
+  }
+  ```
 - primaryKey: One or more columns representing the primary key. Accept either an array or a single value. (default: `id`)
 - returnCols:
   list of columns retrieved by the query

--- a/lib/queries/select.spec.js
+++ b/lib/queries/select.spec.js
@@ -28,14 +28,14 @@ describe('select', () => {
 
     it('should use a "WITH result AS" query if querying on a joined table', () => {
         const { sql, parameters } = select({
-            table: 'table1 JOIN table2 ON table1.table2_id table2.id',
+            table: 'table1 JOIN table2 ON table1.table2_id = table2.id',
             primaryKey: ['id'],
             returnCols: ['column1', 'column2'],
         })();
 
         assert.equal(sql, (
 `WITH result AS (
-SELECT column1, column2 FROM table1 JOIN table2 ON table1.table2_id table2.id
+SELECT column1, column2 FROM table1 JOIN table2 ON table1.table2_id = table2.id
 ) SELECT * FROM result ORDER BY id ASC`
 ));
         assert.deepEqual(parameters, {});
@@ -43,7 +43,7 @@ SELECT column1, column2 FROM table1 JOIN table2 ON table1.table2_id table2.id
 
     it('should use a "WITH result AS" query if enabling the withQuery extraOptions', () => {
         const { sql, parameters } = select({
-            table: 'table1 JOIN table2 ON table1.table2_id table2.id',
+            table: 'table1 JOIN table2 ON table1.table2_id = table2.id',
             primaryKey: ['id'],
             returnCols: ['column1', 'column2'],
             withQuery: true,
@@ -51,7 +51,7 @@ SELECT column1, column2 FROM table1 JOIN table2 ON table1.table2_id table2.id
 
         assert.equal(sql, (
 `WITH result AS (
-SELECT column1, column2 FROM table1 JOIN table2 ON table1.table2_id table2.id
+SELECT column1, column2 FROM table1 JOIN table2 ON table1.table2_id = table2.id
 ) SELECT * FROM result ORDER BY id ASC`
         ));
         assert.deepEqual(parameters, {});


### PR DESCRIPTION
I had to use a `JOIN` yesterday on a project, and first of all, I had to go into the tests to understand how to add this `JOIN`, and then I had to add the `=` in `table1 JOIN table2 ON table1.table2_id = table2.id` to make it work.